### PR TITLE
Cambios sugeridos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Los miembros actuarán conforme a lo establecido en esta guía y lo defenderán 
 * No se tolerará la discriminación de ningún tipo.
 * Se permiten debates y discusiones siempre regidos por un buen y correcto uso del lenguaje (escrito u oral) y de ninguna forma aquel que degrade o agreda a cualquiera de los miembros.
 * No se permitirán debates o discusiones de temas donde implícita o explícitamente se esté haciendo alusión a una ideología política o religiosa.
-* Cualquier toma de decisiones debe estar presidida por:
+* Cualquier toma de decisiones debe estar precedida por:
   * Una convocatoria de día y medio por los 3 medios principales de comunicaciones que tiene la **CSLve** (a saber: Telegram, IRC y Slack)
   * Una decisión, previa al comienzo de la reunión o debate, de la metodología a seguir así como los mecanismos para lograr el acuerdo en las decisiones a tomar.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Los miembros actuarán conforme a lo establecido en esta guía y lo defenderán 
 * Cualquier toma de decisiones debe estar precedida por:
   * Una convocatoria de día y medio por los 3 medios principales de comunicaciones que tiene la **CSLve** (a saber: Telegram, IRC y Slack)
   * Una decisión, previa al comienzo de la reunión o debate, de la metodología a seguir así como los mecanismos para lograr el acuerdo en las decisiones a tomar.
+* Para las reuniones cuyo objetivo sea difundir un mensaje al colectivo o tomar algún tipo de desición se debe realizar y publicar minuta de la misma, la cual debe contener:
+  * Los temas o puntos tratados en la reunión indicando su(s) proponente(s) en caso que se trate de una propuesta de acción de algún participante.
+  * Decisiones alcanzadas para cada punto tratado durante la reunión y la forma en la cual se alcanzaron (acuerdo, consenso, votación) junto con los detalles pertinentes (número de votos, etc.)
+  * Listado de asistentes a la reunion.
+  * Documentos anexos
+    * Registro completo de los mensajes enviados al canal donde se desarrolla la reunión durante el transcurso de la misma.
+    * Documentos discutidos o URL de los mismos.
+* Todas las minutas de reunión deberán almacenarse de manera pública en un único repositorio perteneciente a *cslve* en github.
 
 ## 2. Consecuencias del comportamiento inaceptable
 

--- a/README.md
+++ b/README.md
@@ -51,5 +51,8 @@ Con la finalidad de mantener un sano ambiente se recomienda a los participantes 
 
 
 ## 7. Firmantes
+
 #### Colocar tu nombre acá será suficiente para indicar que se aceptan los términos del código.
+
 - Eduard Lucena (**@X3MLinux**)
+- Luis Salazar (l4sh)

--- a/README.md
+++ b/README.md
@@ -34,12 +34,22 @@ Los miembros actuarán conforme a lo establecido en esta guía y lo defenderán 
 ## 3. Políticas de moderación
 
 
-## 4. Contacto 
+## 4. Recomendaciones
+
+Con la finalidad de mantener un sano ambiente se recomienda a los participantes lo siguiente:
+
+* Mantenerse en el tema de discusión.
+* Ser civilizado y considerado. Evite ser grosero o irrespetuoso y responda siempre manteniendo un alto nivel de civismo y respeto.
+* Asumir en lo posible *buena fe* de la contraparte. En el caso de la comunicación escrita es fácil interpretar de manera incorrecta cualquier expresión. Se recomienda asumir que las otras partes presentes en la discusión actúan de buena fe y solicitar aclaratorias en caso de confusión para evitar malentendidos.
+* Ser colaborativo. En caso que algún miembro requiera asistencia o información en relación algun tema tratado colaborar en la medida de lo posible.
+* Respetar las decisiones alcanzadas como comunidad. En caso de no estar de acuerdo con alguna decisión seguir los canales regulares para reabrir el debate.
+
+## 5. Contacto 
 
 
-## 5. Licencia y atribución
+## 6. Licencia y atribución
 
 
-## 6. Firmantes
+## 7. Firmantes
 #### Colocar tu nombre acá será suficiente para indicar que se aceptan los términos del código.
 - Eduard Lucena (**@X3MLinux**)

--- a/README.md
+++ b/README.md
@@ -16,14 +16,6 @@ Los miembros actuarán conforme a lo establecido en esta guía y lo defenderán 
 * Cualquier toma de decisiones debe estar precedida por:
   * Una convocatoria de día y medio por los 3 medios principales de comunicaciones que tiene la **CSLve** (a saber: Telegram, IRC y Slack)
   * Una decisión, previa al comienzo de la reunión o debate, de la metodología a seguir así como los mecanismos para lograr el acuerdo en las decisiones a tomar.
-* Para las reuniones cuyo objetivo sea difundir un mensaje al colectivo o tomar algún tipo de desición se debe realizar y publicar minuta de la misma, la cual debe contener:
-  * Los temas o puntos tratados en la reunión indicando su(s) proponente(s) en caso que se trate de una propuesta de acción de algún participante.
-  * Decisiones alcanzadas para cada punto tratado durante la reunión y la forma en la cual se alcanzaron (acuerdo, consenso, votación) junto con los detalles pertinentes (número de votos, etc.)
-  * Listado de asistentes a la reunion.
-  * Documentos anexos
-    * Registro completo de los mensajes enviados al canal donde se desarrolla la reunión durante el transcurso de la misma.
-    * Documentos discutidos o URL de los mismos.
-* Todas las minutas de reunión deberán almacenarse de manera pública en un único repositorio perteneciente a *cslve* en github.
 
 ## 2. Consecuencias del comportamiento inaceptable
 


### PR DESCRIPTION
Se reemplazó _presidida_ por _precedida_ ya que el sentido del texto indica que las acciones listadas deben ocurrir con antelación y _presidida_ se refiere a presidencia.

Se agregaron lineamientos base para las minutas de reunión para estandarizar el minimo de contenido de la minuta.

Se agregó sección de _recomendaciones_ con sugerencias orientadas a mantener un ambiente de discusión sano.
